### PR TITLE
fix: adjust font-weight and leading in about.tsx and rootlayout

### DIFF
--- a/src/app/blocks/about.tsx
+++ b/src/app/blocks/about.tsx
@@ -11,14 +11,12 @@ type InfoCardProps = {
 
 const InfoCard = ({ statValue, statTitle, statDescription }: InfoCardProps) => (
   <div className="flex flex-col gap-1 bg-gray-100  p-6 dark:bg-indigo-900">
-    <em className="text-4xl font-bold not-italic leading-normal text-blue-500 dark:text-rose-500">
+    <em className="text-4xl font-bold not-italic text-blue-500 dark:text-rose-500">
       {statValue}
     </em>
     <div className="flex flex-col gap-2">
-      <em className="text-base font-bold not-italic leading-tight">
-        {statTitle}
-      </em>
-      <p className="font-normal leading-tight">{statDescription}</p>
+      <em className="text-base font-bold not-italic">{statTitle}</em>
+      <p>{statDescription}</p>
     </div>
   </div>
 )
@@ -34,7 +32,7 @@ export const About = () => {
               <h2 className="text-3xl font-medium uppercase leading-tight md:text-4xl">
                 Securing the digital world
               </h2>
-              <p className="text-base font-normal leading-tight">
+              <p>
                 Join engineers, security experts, thought leaders, open source
                 maintainers, and executives from around the world for a of day
                 of conversations on the future of Ory. Register now for your

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,7 +11,7 @@ export const metadata = {
     template: "%s | Ory Summit 2023",
   },
   description:
-    "A one-day conference around open source end-to-end security and zero trust solutions for the Ory Community - customers, developers, maintainers, and partners.",
+    "A one-day conference around open source end-to-end security and zero trust solutions for the Ory Community — customers, developers, maintainers, and partners.",
 }
 
 const jetbrainsMono = JetBrains_Mono({


### PR DESCRIPTION
slight adjustments to fonts on InfoCard and globally inside the root layout. now global leading is `leading-normal` (tailwindcss default) and the font-weight is `font-light`. This is a deviation from design-files, where the leading for body is `leading-tight`. It reads easier this way