### PR TITLE
feat: prefill company data

### DIFF
--- a/src/app/register/hubspot-registration-form.tsx
+++ b/src/app/register/hubspot-registration-form.tsx
@@ -60,7 +60,7 @@ const createForm = (afterSubmitted: () => void, session: Session) => {
             const input = form.querySelector<HTMLInputElement>(
               `[name="${formName}"]`,
             )
-            if (input) {
+            if (input && value) {
               input.value = value ?? ""
               input.dispatchEvent(new Event("input"))
             }

--- a/src/app/register/hubspot-registration-form.tsx
+++ b/src/app/register/hubspot-registration-form.tsx
@@ -29,30 +29,42 @@ const createForm = (afterSubmitted: () => void, session: Session) => {
         target: `#${registrationFormId}`,
         onFormSubmitted: afterSubmitted,
         onFormReady: (form: HTMLFormElement) => {
-          const emailInput =
-            form.querySelector<HTMLInputElement>('[name="email"]')
-          const firstNameInput =
-            form.querySelector<HTMLInputElement>('[name="firstname"]')
-          const lastNameInput =
-            form.querySelector<HTMLInputElement>('[name="lastname"]')
           const { email, name }: { email: string; name: string } =
             session.identity.traits
           const names = name.split(" ")
-          const lastName = names.at(-1)
-          const firstNames = names.slice(0, -1).join(" ")
 
-          if (emailInput) {
-            emailInput.value = email
-            emailInput.dispatchEvent(new Event("input"))
-          }
-          if (firstNameInput) {
-            firstNameInput.value = firstNames
-            firstNameInput.dispatchEvent(new Event("input"))
-          }
-          if (lastNameInput) {
-            lastNameInput.value = lastName ?? ""
-            lastNameInput.dispatchEvent(new Event("input"))
-          }
+          const prefillDescriptors = [
+            {
+              formName: "email",
+              value: email,
+            },
+            {
+              formName: "firstname",
+              value: names.slice(0, -1).join(" "),
+            },
+            {
+              formName: "lastname",
+              value: names.at(-1),
+            },
+            {
+              formName: "company",
+              value: session.identity.traits.details?.company,
+            },
+            {
+              formName: "jobtitle",
+              value: session.identity.traits.details?.jobtitle,
+            },
+          ]
+
+          prefillDescriptors.forEach(({ formName, value }) => {
+            const input = form.querySelector<HTMLInputElement>(
+              `[name="${formName}"]`,
+            )
+            if (input) {
+              input.value = value ?? ""
+              input.dispatchEvent(new Event("input"))
+            }
+          })
         },
       })
     },


### PR DESCRIPTION
Closes #55.

This is hard to test currently as the extended company data form hasn't been released yet. I see two options for releasing this:

1. Test locally, ensure that it doesn't break for the current ID schema / users that haven't added their data and then release now (assuming no other issues are found, of course). I've done all of this testing but the reviewer should check anyways, just to be sure.
2. Wait until the form has been released, then have the staging URL point to this preview so we can send the whoami request without CORS issues. Then test both for updated and non-updated users.