### PR TITLE
feat: add redirects for general 404 and about

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,7 @@
+import { redirect } from "next/navigation"
+
+const AboutNotFound = () => {
+  redirect("/#about")
+}
+
+export default AboutNotFound

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,7 +1,0 @@
-import { redirect } from "next/navigation"
-
-const AboutNotFound = () => {
-  redirect("/#about")
-}
-
-export default AboutNotFound

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,7 @@
+import { redirect } from "next/navigation"
+
+const NotFound = () => {
+  redirect("/")
+}
+
+export default NotFound

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,6 +20,7 @@ export default function Page() {
       </div>
       <div
         className={cn(paddingClassnames, dividerStyles, "flex justify-center")}
+        id="about"
       >
         <About />
       </div>

--- a/vercel.json
+++ b/vercel.json
@@ -16,6 +16,11 @@
       "permanent": false
     },
     {
+      "source": "/speakers",
+      "destination": "/#speakers",
+      "permanent": false
+    },
+    {
       "source": "/stage/main",
       "destination": "/",
       "permanent": false

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,24 @@
+{
+  "redirects": [
+    {
+      "source": "/about",
+      "destination": "/#about",
+      "permanent": false
+    },
+    {
+      "source": "/venue",
+      "destination": "/#venue",
+      "permanent": false
+    },
+    {
+      "source": "/schedule",
+      "destination": "/#agenda",
+      "permanent": false
+    },
+    {
+      "source": "/stage/main",
+      "destination": "/",
+      "permanent": false
+    }
+  ]
+}


### PR DESCRIPTION
Adds an anchor to about section to redirect to from `/about`. Also redirects all other URLs to `/` to handle potential old backlinks. Also, once the venue section is added, a redirect will be added for that as well.