### PR TITLE
fix: resolve system theme when no preference was set

### DIFF
--- a/src/app/components/background-video.tsx
+++ b/src/app/components/background-video.tsx
@@ -19,7 +19,7 @@ const ClientSideOnly = ({ children }: PropsWithChildren) => {
 }
 
 export const BackgroundVideo = () => {
-  const { theme } = useTheme()
+  const { resolvedTheme: theme } = useTheme()
   const prefersReducedMotion = usePrefersReducedMotion()
   const videoRef = useRef<HTMLVideoElement>(null)
 


### PR DESCRIPTION
The `theme` property defaults to `system` if no preference has been set manually, which isn't resolved by us and ends up in the video being light even when the user has a system-wide dark theme. Using `resolvedTheme` is the active theme when one has been chosen, but also resolves the system preference otherwise. https://github.com/pacocoursey/next-themes#usetheme-1