### PR TITLE
feat: make ory ID optional for registration

### DIFF
--- a/src/app/(summit-pages)/register/hubspot-registration-form.tsx
+++ b/src/app/(summit-pages)/register/hubspot-registration-form.tsx
@@ -18,7 +18,7 @@ const executeAsSoonAsPossible = (condition: () => boolean, fn: () => void) => {
   }
 }
 
-const createForm = (afterSubmitted: () => void, session: Session) => {
+const createForm = (afterSubmitted: () => void, session?: Session) => {
   executeAsSoonAsPossible(
     () => Boolean((window as any)?.hbspt?.forms?.create),
     () => {
@@ -29,6 +29,10 @@ const createForm = (afterSubmitted: () => void, session: Session) => {
         target: `#${registrationFormId}`,
         onFormSubmitted: afterSubmitted,
         onFormReady: (form: HTMLFormElement) => {
+          if (!session) {
+            return
+          }
+
           const { email, name }: { email: string; name: string } =
             session.identity.traits
           const names = name.split(" ")
@@ -77,7 +81,7 @@ export const HubspotRegistrationForm = ({
   className,
 }: HubspotRegistrationFormProps) => {
   const router = useRouter()
-  const { data: session } = useSession()
+  const { data: session, isLoading: sessionIsLoading } = useSession()
   const { mutate: mutateRegistration } = useRegistration()
 
   const mutateRegistrationRef = useRef(mutateRegistration)
@@ -90,7 +94,7 @@ export const HubspotRegistrationForm = ({
       router.push("see-you-soon")
     }
 
-    if (!formHasRendered && session) {
+    if (!formHasRendered && !sessionIsLoading) {
       createForm(afterSubmitted, session)
       setFormHasRendered(true)
     }

--- a/src/app/(summit-pages)/register/page.tsx
+++ b/src/app/(summit-pages)/register/page.tsx
@@ -1,8 +1,6 @@
 "use client"
 
-import { useLoginUrl } from "@/hooks/useLoginUrl"
 import { useIsRegistered } from "@/hooks/useRegistration"
-import { useSession } from "@/hooks/useSession"
 import { cn } from "@/utils/cn"
 import { redirect } from "next/navigation"
 import { Container } from "../../components/container"
@@ -11,13 +9,7 @@ import { Wrapper } from "../../components/wrapper"
 import { HubspotRegistrationForm } from "./hubspot-registration-form"
 
 export default function RegistrationPage() {
-  const { data: session, isLoading: sessionIsLoading } = useSession()
   const { data: isRegistered } = useIsRegistered()
-  const loginUrl = useLoginUrl()
-
-  if (!sessionIsLoading && !session?.active) {
-    redirect(loginUrl)
-  }
 
   if (isRegistered) {
     redirect("/see-you-soon")

--- a/src/app/components/get-ticket-button.tsx
+++ b/src/app/components/get-ticket-button.tsx
@@ -1,8 +1,6 @@
 "use client"
 
-import { useLoginUrl } from "@/hooks/useLoginUrl"
 import { useIsRegistered } from "@/hooks/useRegistration"
-import { useSession } from "@/hooks/useSession"
 import Link from "next/link"
 import { Button } from "./button"
 import { RightArrow } from "./right-arrow"
@@ -13,31 +11,19 @@ type GetTicketButtonProps = {
 }
 
 export const GetTicketButton = ({ className, id }: GetTicketButtonProps) => {
-  const { data: session } = useSession()
   const { data: isRegistered } = useIsRegistered()
-  const loginUrl = useLoginUrl()
 
   if (isRegistered) {
     return null
   }
 
-  const getTicketButtonContent = (
-    <>
+  return (
+    <Button as={Link} id={id} href="/register" className={className}>
       <RightArrow className="md:hidden" />
       <span className="hidden text-sm leading-none md:inline-block">
         Get your ticket
       </span>
       <span className="text-sm leading-none md:hidden">Ticket</span>
-    </>
-  )
-
-  return session ? (
-    <Button as={Link} id={id} href="/register" className={className}>
-      {getTicketButtonContent}
-    </Button>
-  ) : (
-    <Button as={"a"} id={id} className={className} href={loginUrl}>
-      {getTicketButtonContent}
     </Button>
   )
 }


### PR DESCRIPTION
These changes are complete and make the Ory ID optional for registering for Ory Summit. If a user happens to be logged in, their data will still be pre-filled.

Draft until green-lighted by management.