### PR TITLE
fix: pick correct current talk

### DIFF
--- a/src/app/components/countdown.tsx
+++ b/src/app/components/countdown.tsx
@@ -1,8 +1,8 @@
 "use client"
 
+import { useCurrentDate } from "@/hooks/useCurrentDate"
 import { cn } from "@/utils/cn"
 import dynamic from "next/dynamic"
-import { useEffect, useState } from "react"
 import { RightArrow } from "./right-arrow"
 
 type CountdownProps = {
@@ -10,9 +10,9 @@ type CountdownProps = {
   targetDate: string
 }
 
-const getDelta = (targetDate: string) => {
-  const now = new Date().valueOf()
-  const target = new Date(targetDate).valueOf()
+const useDelta = (nowDate: Date, targetDate: Date) => {
+  const now = nowDate.valueOf()
+  const target = targetDate.valueOf()
   const delta = Math.max(0, target - now)
   const totalSeconds = Math.floor(delta / 1_000)
   const seconds = totalSeconds % 60
@@ -28,15 +28,8 @@ const getDelta = (targetDate: string) => {
 const toTwoDigits = (n: number) => n.toString().padStart(2, "0")
 
 const Countdown = ({ className, targetDate }: CountdownProps) => {
-  const [{ days, hours, minutes, seconds }, setDelta] = useState(
-    getDelta(targetDate),
-  )
-
-  useEffect(() => {
-    const request = requestAnimationFrame(() => setDelta(getDelta(targetDate)))
-
-    return () => cancelAnimationFrame(request)
-  })
+  const now = useCurrentDate()
+  const { days, hours, minutes, seconds } = useDelta(now, new Date(targetDate))
 
   return (
     <div

--- a/src/hooks/useCurrentTalk.ts
+++ b/src/hooks/useCurrentTalk.ts
@@ -1,13 +1,23 @@
 import { useCurrentDate } from "@/hooks/useCurrentDate"
 import { useTalks } from "@/hooks/useTalks"
+import { useMemo } from "react"
 
 export const useCurrentTalk = () => {
   const talks = useTalks()
+  const sortedTalks = useMemo(
+    () =>
+      talks.sort((a, b) => {
+        let aDate = new Date(a.startTime).valueOf()
+        let bDate = new Date(b.startTime).valueOf()
+        return aDate - bDate
+      }),
+    [talks],
+  )
   const now = useCurrentDate()
 
   return (
-    talks.findLast(
+    sortedTalks.findLast(
       ({ startTime }) => new Date(startTime).getTime() <= now.getTime(),
-    ) ?? talks[0]
+    ) ?? sortedTalks[0]
   )
 }


### PR DESCRIPTION
To verify, please perform the following changes:

```diff
--- a/src/hooks/useCurrentDate.ts
+++ b/src/hooks/useCurrentDate.ts
@@ -1,10 +1,14 @@
 import { useEffect, useState } from "react"
 
 export const useCurrentDate = () => {
-  const [now, setNow] = useState(new Date())
+  const date = new Date()
+  date.setDate(9)
+  const [now, setNow] = useState(date)
   useEffect(() => {
     const request = requestAnimationFrame(() => {
-      setNow(new Date())
+      const date = new Date()
+      date.setDate(9)
+      setNow(date)
     })
 
     return () => cancelAnimationFrame(request)

```

If you want to test with a live stream, you can set `NEXT_PUBLIC_YOUTUBE_VIDEO_ID` in your `.env.local` (example video ID: `6k3gK6pxskE` 🎧 )